### PR TITLE
Added stats.nba.com api

### DIFF
--- a/src/apis/stats_nba_com.py
+++ b/src/apis/stats_nba_com.py
@@ -1,0 +1,72 @@
+import json
+import selenium
+import sys
+from selenium import webdriver
+from time import sleep
+
+
+BROWSER_LOAD_DELAY = 6
+
+
+conn = None
+def get_connection():
+    """Returns a StatsNbaComApi connection
+    """
+    global conn
+    if conn is None:
+        conn = StatsNbaComApi()
+    return conn
+
+
+class StatsNbaComApi:
+    """
+    A stats.nba.com API using selenium.
+    """
+    def __init__(self):
+        self.browser = None
+
+    def __del__(self):
+        if self.browser:
+            self.browser.close()
+
+    def connect(self):
+        """Connects to the stats.nba.com API through a browser window.
+        Does not seem to work with headless browsers.
+        """
+        if self.browser:
+            return
+        options = webdriver.ChromeOptions()
+        self.browser = webdriver.Chrome(options=options)
+        self.browser.get('https://stats.nba.com')
+        sleep(BROWSER_LOAD_DELAY)
+
+    def get(self, uri):
+        """Sends an API request to stats.nba.com
+        """
+        if self.browser is None:
+            self.connect()
+        return json.loads(self.browser.execute_script(f'''
+            var req = new XMLHttpRequest();
+            req.open("GET", "{uri}", false);
+            req.send(null);
+            return req.responseText;
+        '''))
+
+
+if __name__ == '__main__':
+    """When run as a main, the program fetches and prints a stats.nba.com uri.
+    Program takes one argument: the url to lead
+    """
+
+    ## Exit if the program was run without a single arg: the URL
+    if len(sys.argv) != 2:
+        print('Program takes one arg: the uri to fetch')
+        sys.exit(1)
+    
+    ## Create an API instance
+    api = StatsNbaComApi()
+
+    ## Fetch the data
+    uri = sys.argv[1]
+    data = api.get(uri)
+    print(data)

--- a/src/tools.py
+++ b/src/tools.py
@@ -1,38 +1,17 @@
-import requests
 import pandas as pd
+from apis.stats_nba_com import get_connection
 
-games_header = {
-    'user-agent': 'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) '
-                  'Chrome/57.0.2987.133 Safari/537.36',
-    'Dnt': '1',
-    'Accept-Encoding': 'gzip, deflate, sdch',
-    'Accept-Language': 'en',
-    'origin': 'http://stats.nba.com',
-    'Referer': 'https://github.com'
-}
 
-data_headers = {
-    'Accept': 'application/json, text/plain, */*',
-    'Accept-Encoding': 'gzip, deflate, br',
-    'Host': 'stats.nba.com',
-    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4 Safari/605.1.15',
-    'Accept-Language': 'en-us',
-    'Referer': 'https://stats.nba.com/teams/traditional/?sort=W_PCT&dir=-1&Season=2019-20&SeasonType=Regular%20Season',
-    'Connection': 'keep-alive',
-    'x-nba-stats-origin': 'stats',
-    'x-nba-stats-token': 'true'
-}
+conn = get_connection()
 
 
 def get_json_data(url):
-    raw_data = requests.get(url, headers=data_headers)
-    json = raw_data.json()
+    json = conn.get(url)
     return json.get('resultSets')
 
 
 def get_todays_games_json(url):
-    raw_data = requests.get(url, headers=games_header)
-    json = raw_data.json()
+    json = conn.get(url)
     return json.get('gs').get('g')
 
 


### PR DESCRIPTION
Changes Made:
* Added `src/api/stats_nba_com.py`, which is a stats.nba.com API that lets you send HTTP requests to stats.nba.com URLs
* Updated `src/tools.py` to use the new API

Testing Done:
* Verified that API requests indeed work, when using `src/apis/stats_nba_com.py`
* Verified that the `tools.get_todays_games_json` method works, by running the following in my interpreter:
```
>>> import tools
>>> tools.get_todays_games_json('https://data.nba.com/data/10s/v2015/json/mobile_teams/nba/2020/scores/00_todays_scores.json')
```