### PR TITLE
Second PR for Kelly Criterion to give suggested wager amounts

### DIFF
--- a/src/Predict/XGBoost_Runner.py
+++ b/src/Predict/XGBoost_Runner.py
@@ -75,6 +75,7 @@ def xgb_runner(data, todays_games_uo, frame_ml, games, home_team_odds, away_team
         home_team = game[0]
         away_team = game[1]
         ev_home = ev_away = 0
+        kelly_home = kelly_away = 0
         if home_team_odds[count] and away_team_odds[count]:
             ev_home = float(Expected_Value.expected_value(ml_predictions_array[count][0][1], int(home_team_odds[count])))
             ev_away = float(Expected_Value.expected_value(ml_predictions_array[count][0][0], int(away_team_odds[count])))

--- a/src/Predict/XGBoost_Runner.py
+++ b/src/Predict/XGBoost_Runner.py
@@ -78,15 +78,17 @@ def xgb_runner(data, todays_games_uo, frame_ml, games, home_team_odds, away_team
         if home_team_odds[count] and away_team_odds[count]:
             ev_home = float(Expected_Value.expected_value(ml_predictions_array[count][0][1], int(home_team_odds[count])))
             ev_away = float(Expected_Value.expected_value(ml_predictions_array[count][0][0], int(away_team_odds[count])))
+            kelly_home = float(Expected_Value.kelly(ml_predictions_array[count][0][1], int(home_team_odds[count])))
+            kelly_away = float(Expected_Value.kelly(ml_predictions_array[count][0][0], int(away_team_odds[count])))
         if ev_home > 0:
-            print(home_team + ' EV: ' + Fore.GREEN + str(ev_home) + Style.RESET_ALL)
+            print(home_team + ' EV: ' + Fore.GREEN + str(ev_home) + Style.RESET_ALL + ' Wager: $' + str(kelly_home))
         else:
-            print(home_team + ' EV: ' + Fore.RED + str(ev_home) + Style.RESET_ALL)
+            print(home_team + ' EV: ' + Fore.RED + str(ev_home) + Style.RESET_ALL + ' Wager: $' + str(kelly_home))
 
         if ev_away > 0:
-            print(away_team + ' EV: ' + Fore.GREEN + str(ev_away) + Style.RESET_ALL)
+            print(away_team + ' EV: ' + Fore.GREEN + str(ev_away) + Style.RESET_ALL + ' Wager: $' + str(kelly_away))
         else:
-            print(away_team + ' EV: ' + Fore.RED + str(ev_away) + Style.RESET_ALL)
+            print(away_team + ' EV: ' + Fore.RED + str(ev_away) + Style.RESET_ALL + ' Wager: $' + str(kelly_away))
         count += 1
 
     deinit()

--- a/src/Utils/Expected_Value.py
+++ b/src/Utils/Expected_Value.py
@@ -9,3 +9,16 @@ def payout(odds):
         return odds
     else:
         return (100 / (-1 * odds)) * 100
+
+def k_odds(american_odds):
+    if american_odds > 0:
+        return (american_odds/100)
+    else:
+        return -1 * (100/american_odds)
+
+def kelly(Pwin, american_odds, bankroll=100, adjustment=1.0):
+    odds = k_odds(american_odds)
+    f = Pwin - ((1 - Pwin)/odds)
+    wager = (f * bankroll) / adjustment
+    wager = 0 if wager < 0 else wager
+    return round(wager,2)


### PR DESCRIPTION
First PR: https://github.com/kyleskom/NBA-Machine-Learning-Sports-Betting/pull/221

Currently the model ignores EV to pick its winner. People want to use this tool to place wagers, and smart wagering is based on expected value. Kelly Criterion suggests an amount to wager taking into account the EV as well as the odds.
I have not ran any tests on data but I can assume that based on the spreadsheet tracking the success, it would be higher following Kelly wagering. I have the output as follows:

![image](https://user-images.githubusercontent.com/111388546/234682310-bb87f128-5f52-4e96-935c-12f0c946e905.png)
