### PR TITLE
Fix for TypeError when odds aren't complete 

### DIFF
--- a/src/Predict/NN_Runner.py
+++ b/src/Predict/NN_Runner.py
@@ -68,6 +68,10 @@ def nn_runner(data, todays_games_uo, frame_ml, games, home_team_odds, away_team_
         home_team = game[0]
         away_team = game[1]
         ev_home = ev_away = 0
+        if home_team_odds[count] is None or away_team_odds[count] is None:
+            print('Incomplete Odds data - unable to calculate further')
+            deinit()
+            return
         if home_team_odds[count] and away_team_odds[count]:
             ev_home = float(Expected_Value.expected_value(ml_predictions_array[count][0][1], int(home_team_odds[count])))
             ev_away = float(Expected_Value.expected_value(ml_predictions_array[count][0][0], int(away_team_odds[count])))

--- a/src/Predict/XGBoost_Runner.py
+++ b/src/Predict/XGBoost_Runner.py
@@ -80,6 +80,10 @@ def xgb_runner(data, todays_games_uo, frame_ml, games, home_team_odds, away_team
         home_team = game[0]
         away_team = game[1]
         ev_home = ev_away = 0
+        if home_team_odds[count] is None or away_team_odds[count] is None:
+            print('Incomplete Odds data - unable to calculate further')
+            deinit()
+            return
         if home_team_odds[count] and away_team_odds[count]:
             ev_home = float(Expected_Value.expected_value(ml_predictions_array[count][0][1], int(home_team_odds[count])))
             ev_away = float(Expected_Value.expected_value(ml_predictions_array[count][0][0], int(away_team_odds[count])))
@@ -88,9 +92,9 @@ def xgb_runner(data, todays_games_uo, frame_ml, games, home_team_odds, away_team
         bankroll_descriptor = ' Fraction of Bankroll: '
         bankroll_fraction_home = bankroll_descriptor + str(kc.calculate_kelly_criterion(home_team_odds[count], ml_predictions_array[count][0][1])) + '%'
         bankroll_fraction_away = bankroll_descriptor + str(kc.calculate_kelly_criterion(away_team_odds[count], ml_predictions_array[count][0][0])) + '%'
-
+        print('bankroll fractions')
         print(home_team + ' EV: ' + expected_value_colors['home_color'] + str(ev_home) + Style.RESET_ALL + (bankroll_fraction_home if kelly_criterion else ''))
         print(away_team + ' EV: ' + expected_value_colors['away_color'] + str(ev_away) + Style.RESET_ALL + (bankroll_fraction_away if kelly_criterion else ''))
         count += 1
-
+    
     deinit()

--- a/src/Predict/XGBoost_Runner.py
+++ b/src/Predict/XGBoost_Runner.py
@@ -92,7 +92,7 @@ def xgb_runner(data, todays_games_uo, frame_ml, games, home_team_odds, away_team
         bankroll_descriptor = ' Fraction of Bankroll: '
         bankroll_fraction_home = bankroll_descriptor + str(kc.calculate_kelly_criterion(home_team_odds[count], ml_predictions_array[count][0][1])) + '%'
         bankroll_fraction_away = bankroll_descriptor + str(kc.calculate_kelly_criterion(away_team_odds[count], ml_predictions_array[count][0][0])) + '%'
-        print('bankroll fractions')
+
         print(home_team + ' EV: ' + expected_value_colors['home_color'] + str(ev_home) + Style.RESET_ALL + (bankroll_fraction_home if kelly_criterion else ''))
         print(away_team + ' EV: ' + expected_value_colors['away_color'] + str(ev_away) + Style.RESET_ALL + (bankroll_fraction_away if kelly_criterion else ''))
         count += 1


### PR DESCRIPTION
Handling for when odds aren't present to prevent the TypeError: '>=' not supported between instances of 'NoneType' and 'int' error.  This occurs when odds are incomplete and the KC function is called

See: https://github.com/kyleskom/NBA-Machine-Learning-Sports-Betting/issues/345


