### PR TITLE
Add POST endpoint to receive and process requests

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from src.DataProviders.SbrOddsProvider import SbrOddsProvider
 from src.Predict import NN_Runner, XGBoost_Runner
 from src.Utils.Dictionaries import team_index_current
 from src.Utils.tools import create_todays_games_from_odds, get_json_data, to_data_frame, get_todays_games_json, create_todays_games
+from src.Inference.inference import retreive_model_inference_result
 
 todays_games_url = 'https://data.nba.com/data/10s/v2015/json/mobile_teams/nba/2024/scores/00_todays_scores.json'
 data_url = 'https://stats.nba.com/stats/leaguedashteamstats?' \
@@ -126,14 +127,3 @@ def main():
         print("------------Neural Network Model Predictions-----------")
         NN_Runner.nn_runner(data, todays_games_uo, frame_ml, games, home_team_odds, away_team_odds, args.kc)
         print("-------------------------------------------------------")
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Model to Run')
-    parser.add_argument('-xgb', action='store_true', help='Run with XGBoost Model')
-    parser.add_argument('-nn', action='store_true', help='Run with Neural Network Model')
-    parser.add_argument('-A', action='store_true', help='Run all Models')
-    parser.add_argument('-odds', help='Sportsbook to fetch from. (fanduel, draftkings, betmgm, pointsbet, caesars, wynn, bet_rivers_ny')
-    parser.add_argument('-kc', action='store_true', help='Calculates percentage of bankroll to bet based on model edge')
-    args = parser.parse_args()
-    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ tqdm==4.66.1
 flask==3.0.0
 scikit-learn==1.3.1
 toml==0.10.2
+fastapi==0.95.2
+uvicorn==0.22.0

--- a/src/Inference/inference.py
+++ b/src/Inference/inference.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import logging
+
+# Initialize the FastAPI app
+app = FastAPI()
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+
+# Define the request model
+class PredictionRequest(BaseModel):
+    homeTeamName: str
+    awayTeamName: str
+    matchDate: str
+    league: str
+
+# Define the inference endpoint
+@app.post("/inference")
+async def retreive_model_inference_result(request: PredictionRequest):
+    try:
+        # Log input data
+        logging.info("Received prediction request: %s", request.dict())
+
+        # Placeholder for custom model inference logic
+        # Replace with actual model inference code
+        # prediction = make_prediction(request.homeTeamName, request.awayTeamName, request.matchDate, request.league)
+        # return {
+        #     'choice': prediction.choice,
+        #     'probability': prediction.probability
+        # }
+        return {
+            'choice': 'HomeTeam',
+            'probability': 0.2
+        }
+    except Exception as e:
+        logging.error(f"Error inferencing models: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error.")


### PR DESCRIPTION
Add a POST endpoint to receive and process prediction requests.

* **main.py**
  - Import `retreive_model_inference_result` function from `src/Inference/inference.py`
  - Remove the `if __name__ == "__main__":` block

* **src/Inference/inference.py**
  - Create a new file to define the `retreive_model_inference_result` function
  - Import necessary modules and classes from FastAPI, Pydantic, and logging
  - Define the `PredictionRequest` model class
  - Implement the `retreive_model_inference_result` function to handle the POST request

* **requirements.txt**
  - Add `fastapi` and `uvicorn` to the list of dependencies

