### PR TITLE
Support Python 3.12+ / TensorFlow 2.16 (Keras 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,18 @@ This project predicts NBA game winners and totals (over/under) using team stats 
 4. **Predict today**: `main.py` fetches today’s schedule, builds matchup features, loads trained models, and prints predictions, expected value, and optional Kelly Criterion sizing.
 
 ## Requirements
-- Python 3.11
-- Packages: Tensorflow, XGBoost, NumPy, Pandas, Colorama, Tqdm, Requests, Scikit-learn
+- Python 3.12+ (tested on 3.12)
+- Packages: TensorFlow, tf-keras, XGBoost, NumPy, Pandas, Colorama, Tqdm, Scikit-learn (see `requirements.txt`)
+- macOS only: XGBoost needs OpenMP: `brew install libomp`
 
 Install dependencies:
 ```bash
 pip3 install -r requirements.txt
 ```
+
+> The shipped NN models were trained with Keras 2. TensorFlow >= 2.16 ships
+> Keras 3, so the entry points set `TF_USE_LEGACY_KERAS=1` to load them through
+> the `tf-keras` backend.
 
 ## Quick start
 ```bash

--- a/main.py
+++ b/main.py
@@ -1,5 +1,9 @@
 import argparse
+import os
 from datetime import datetime, timedelta
+
+# Load the Keras-2 NN models via tf-keras; must precede the tensorflow import.
+os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
 
 import pandas as pd
 import tensorflow as tf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
-colorama==0.4.6
-pandas==2.1.1
-sbrscrape==0.0.10
-tensorflow==2.14.0
-#tensorflow-metal==1.1.0
-xgboost==2.0.0
-tqdm==4.66.1
-flask==3.0.0
-scikit-learn==1.3.1
-toml==0.10.2
+colorama>=0.4.6
+pandas>=2.2
+sbrscrape>=0.0.12
+tensorflow>=2.16
+# tf-keras provides the Keras 2 backend (enabled via TF_USE_LEGACY_KERAS) so the
+# pretrained NN models, saved with Keras 2, load on TF>=2.16, which ships Keras 3.
+tf-keras>=2.16
+h5py>=3.10
+xgboost>=2.0
+tqdm>=4.66
+flask>=3.0
+scikit-learn>=1.4
+toml>=0.10.2

--- a/scripts/check_feature_alignment.py
+++ b/scripts/check_feature_alignment.py
@@ -12,12 +12,15 @@ try:
 except ImportError:
     xgb = None
 
-try:
-    from keras.models import load_model
-except ImportError:
-    load_model = None
-
 BASE_DIR = Path(__file__).resolve().parents[1]
+
+# Make the ``src`` package importable when run as a standalone script, then reuse
+# the shared Keras-2 compatibility loader for the pretrained NN models.
+sys.path.insert(0, str(BASE_DIR))
+try:
+    from src.Utils.model_loader import load_legacy_model
+except ImportError:
+    load_legacy_model = None
 DATASET_DB = BASE_DIR / "Data" / "dataset.sqlite"
 MODEL_DIR = BASE_DIR / "Models"
 
@@ -93,10 +96,10 @@ def describe_model_input(model_path, label):
     if model_path is None:
         print(f"{label} model: not found")
         return None
-    if load_model is None:
+    if load_legacy_model is None:
         print(f"{label} model: keras not installed")
         return None
-    model = load_model(str(model_path), compile=False)
+    model = load_legacy_model(model_path)
     input_features = model.input_shape[-1]
     print(f"{label} model input features: {input_features} ({model_path})")
     return input_features

--- a/src/Predict/NN_Runner.py
+++ b/src/Predict/NN_Runner.py
@@ -1,13 +1,17 @@
 import copy
+import os
 import re
 from pathlib import Path
+
+# Keras-2 models: force the tf-keras backend before tensorflow is imported.
+os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
 
 import numpy as np
 import tensorflow as tf
 from colorama import Fore, Style, init, deinit
-from keras.models import load_model
 from src.Utils import Expected_Value
 from src.Utils import Kelly_Criterion as kc
+from src.Utils.model_loader import load_legacy_model
 
 init()
 
@@ -54,10 +58,10 @@ def _load_models():
     global _model, _ou_model
     if _model is None:
         ml_path = _select_best_model("Trained-Model-ML-", ML_PATTERN)
-        _model = load_model(str(ml_path), compile=False)
+        _model = load_legacy_model(ml_path)
     if _ou_model is None:
         ou_path = _select_best_model("Trained-Model-OU-", OU_PATTERN)
-        _ou_model = load_model(str(ou_path), compile=False)
+        _ou_model = load_legacy_model(ou_path)
 
 
 def nn_runner(data, todays_games_uo, frame_ml, games, home_team_odds, away_team_odds, kelly_criterion):

--- a/src/Train-Models/NN_Model_ML.py
+++ b/src/Train-Models/NN_Model_ML.py
@@ -1,7 +1,11 @@
 import argparse
+import os
 import sqlite3
 import time
 from pathlib import Path
+
+# tf-keras backend: keeps optimizers.legacy and the saved-model format on Keras 2.
+os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
 
 import numpy as np
 import pandas as pd

--- a/src/Train-Models/NN_Model_UO.py
+++ b/src/Train-Models/NN_Model_UO.py
@@ -1,6 +1,10 @@
 import argparse
+import os
 import sqlite3
 from pathlib import Path
+
+# Same tf-keras backend as the ML script; keeps optimizers.legacy working.
+os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
 
 import numpy as np
 import pandas as pd

--- a/src/Utils/model_loader.py
+++ b/src/Utils/model_loader.py
@@ -1,0 +1,53 @@
+"""Load the Keras-2 NN models on TensorFlow >= 2.16 (Keras 3).
+
+The .keras files under Models/NN_Models were saved with Keras 2 and don't
+deserialize under Keras 3, so we force the tf-keras backend via
+TF_USE_LEGACY_KERAS (set before tensorflow is imported). load_legacy_model
+falls back to rebuilding from config.json + model.weights.h5 when tf-keras
+can't read the archive directly.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import zipfile
+
+os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
+
+
+def load_legacy_model(path):
+    """Load a Keras-2 ``.keras`` model on a modern TensorFlow/Keras stack."""
+    import tf_keras
+
+    path = str(path)
+    try:
+        return tf_keras.models.load_model(path, compile=False)
+    except Exception:
+        return _rebuild_from_archive(path)
+
+
+def _rebuild_from_archive(path):
+    """Fallback: rebuild architecture from config and map weights by layer."""
+    import h5py
+    import tf_keras
+
+    with zipfile.ZipFile(path) as archive:
+        config = json.loads(archive.read("config.json"))
+        tmp_dir = tempfile.mkdtemp()
+        archive.extract("model.weights.h5", tmp_dir)
+        weights_path = os.path.join(tmp_dir, "model.weights.h5")
+
+    model = tf_keras.models.model_from_config(config)
+    model.build(model.input_shape)
+
+    with h5py.File(weights_path, "r") as handle:
+        layer_store = handle["_layer_checkpoint_dependencies"]
+        for layer in model.layers:
+            if layer.name not in layer_store:
+                continue
+            variables = layer_store[layer.name]["vars"]
+            weights = [variables[str(i)][()] for i in range(len(variables.keys()))]
+            if weights:
+                layer.set_weights(weights)
+    return model


### PR DESCRIPTION
## Problem
The pinned deps (`tensorflow==2.14.0`, `scikit-learn==1.3.1`, `pandas==2.1.1`) have no
3.12 wheels, so `pip install -r requirements.txt` fails on 3.12: tensorflow
2.14.0 isn't installable there (2.16.0 is the floor). TF 2.16 ships Keras 3,
which can't load the pretrained NN models (saved with Keras 2, `keras_version`
2.14.0 in each `.keras` archive) and drops APIs the training scripts use
(`tf.keras.optimizers.legacy`).

## Changes
- `requirements.txt`: bump pins to 3.12-compatible floors; add `tf-keras` (Keras 2
  backend) and `h5py`.
- Set `TF_USE_LEGACY_KERAS=1` before tensorflow is imported in every entry point,
  so `tf.keras` resolves to Keras 2. Predict and train both keep working with the
  shipped models.
- `src/Utils/model_loader.py`: `load_legacy_model()` loads the Keras-2 models on the
  new stack; falls back to rebuilding from `config.json` + `model.weights.h5` if
  tf-keras can't read the archive directly.
- README: 3.12+, libomp for XGBoost on macOS, tf-keras note.

## Verified
3.12 / TF 2.21: 32/32 tests pass, both NN and both XGBoost models load and
predict, `main.py` imports clean. No model files touched.

## Follow-ups
- XGBoost calibration `.pkl` (pickled under sklearn 1.3) won't unpickle on 1.9 and
  falls back to uncalibrated output without erroring.
- Could retrain/convert the NN models to Keras 3 native format and drop tf-keras.
